### PR TITLE
Run SonarCloud only on pull requests to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+[![Build Status](https://dev.azure.com/krivchenko1306work/testAzureDevOps/_apis/build/status/Igor1306.mslearn-tailspin-spacegame-web?branchName=master)](https://dev.azure.com/krivchenko1306work/testAzureDevOps/_build/latest?definitionId=1&branchName=master)
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,2 @@
+pool:
+  vmImage: 'Ubuntu-16.04'


### PR DESCRIPTION
Run SonarCloud less often to reduce build times for normal CI builds.

